### PR TITLE
[Bugfix] GLM-5.3-Flash: load redundant expert replicas under EPLB

### DIFF
--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -725,12 +725,24 @@ class Glm5NextModel(nn.Module):
         if self.config.is_moe:
             # Params for weights, fp8 weight scales, fp8 activation scales
             # (param_name, weight_name, expert_id, shard_id)
+            # EPLB: the mapping enumerates physical experts, so it must cover
+            # the redundant replicas or their slots are never loaded.
+            num_redundant_experts = next(
+                (
+                    layer.mlp.n_redundant_experts
+                    for layer in self.layers
+                    if isinstance(layer, Glm5NextDecoderLayer)
+                    and isinstance(layer.mlp, Glm5NextMoE)
+                ),
+                0,
+            )
             expert_params_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
                 num_experts=self.config.n_routed_experts,
+                num_redundant_experts=num_redundant_experts,
             )
         else:
             expert_params_mapping = []
@@ -818,28 +830,38 @@ class Glm5NextModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                for idx, (
+                is_expert_weight = False
+                for (
                     param_name,
                     weight_name,
                     expert_id,
                     expert_shard_id,
-                ) in enumerate(expert_params_mapping):
+                ) in expert_params_mapping:
                     if weight_name not in name:
                         continue
-                    name = name.replace(weight_name, param_name)
-                    if is_pp_missing_parameter(name, self):
+                    # A checkpoint expert may map to several physical replicas
+                    # under EPLB; keep `name` intact and try the next entry
+                    # when this physical expert is not local to the rank.
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+                    if is_pp_missing_parameter(name_mapped, self):
                         continue
-                    param = params_dict[name]
+                    param = params_dict[name_mapped]
                     weight_loader = param.weight_loader
-                    weight_loader(
+                    success = weight_loader(
                         param,
                         loaded_weight,
-                        name,
+                        name_mapped,
                         expert_id=expert_id,
                         shard_id=expert_shard_id,
+                        return_success=True,
                     )
-                    break
+                    if success:
+                        name = name_mapped
+                        break
                 else:
+                    if is_expert_weight:
+                        continue
                     # Skip loading extra bias for GPTQ models.
                     if (
                         name.endswith(".bias")

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -303,6 +303,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts,
+            num_redundant_experts=self.num_redundant_experts,
         )
 
         params_dict = dict(self.named_parameters())


### PR DESCRIPTION
## Purpose

Follow-up to the GLM-5.3-Flash EPLB enablement on this branch (vllm-project/vllm#55119). With that change EPLB starts, but the redundant expert slots never receive weights: after loading, every replica slot (physical experts 288..295, replicas of logical 0..7 in the initial map) has all-zero `w13`/`w2` and uninitialized scale tensors. Tokens routed to a replica get a zero expert contribution, and later rebalances copy from whichever slot the old placement says holds that logical expert, so the empty slots propagate instead of healing.

Two independent defects in `Glm5NextModel.load_weights`, both needed to reach the replica slots:

1. `fused_moe_make_expert_params_mapping` was called without `num_redundant_experts`, so the mapping only enumerated physical experts `0..n_routed_experts-1`; the replica slots had no loading entry at all.
2. The expert loop called the weight loader without `return_success=True` and broke unconditionally after the first matching entry, while also rewriting `name` in place. On the rank holding a replica, the first entry (the non-local primary) is tried and silently skipped, and the loop never reaches the replica entry. This is the pitfall DeepSeek-V2's loader documents ("otherwise we may skip experts with other available replicas").

`Glm5NextMTP.load_weights` already had the correct loop and only needed the mapping argument.

## Test Plan

GLM-5.3-Flash (FP8, `zai-org/GLM-5.3-Flash`) on 4x GB300, TP4 + EP, `enforce_eager`, EPLB config identical to #55119 (`num_redundant_experts=8, window_size=100, step_interval=100, use_async=True`).

After model load, a `collective_rpc` on every EP rank reads each MoE layer's local expert weights, computes per-slot `abs_sum` and nonzero count over `get_expert_weights()`, and compares each redundant physical expert with its primary via `expert_map`. Then a 300-question 5-shot GSM8K run with `tests/evals/gsm8k/gsm8k_eval.py:evaluate_gsm8k_offline`.

## Test Result

| Config | Redundant slots (42 MoE layers x 8) | GSM8K 300q |
|---|---|---|
| no EPLB | n/a (all local slots populated) | 0.9167 |
| `eplb` branch as-is + EPLB | 336/336 differ from primary: `w13`/`w2` all zero, only the two scale tensors (49152 elems) nonzero | 0.9067 |
| this fix + EPLB | 336/336 match primary (`abs_sum` and nonzero count identical) | 0.9100 |

The GSM8K differences are within noise at 300 questions (only 8 of 288 logical experts are affected, about half their traffic); the weight inspection is the decisive check.

`ruff check` / `ruff format --check` (pinned 0.14.0) pass on both files.

## Notes

- The same two patterns exist in other hand-rolled loaders (`hy_v3`, `step3p5`, `mimo_v2`, and the `deepseek_mtp` / `glm4_moe_mtp` / `deepseek_v32` MTP drafters); models using `AutoWeightsLoader` go through `RoutedExperts.load_weights`, which already handles replicas. Those are out of scope here.
- Not a duplicate: no open PR touches GLM5Next expert loading; #55119 adds the `MixtureOfExperts` metadata but does not change `load_weights`.
- AI assistance (Claude Code) was used for the investigation, reproduction and patch; the submitter reviewed every changed line.
